### PR TITLE
Panel de la Jac, administrador de alertas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import AdminDashboard from './components/Admin/AdminDashboard';
 import UserTable from './components/Admin/UserTable';
 import RoleTable from './components/Admin/RoleTable';
 import RoleRoute from './components/Route/RoleRoute';
+import JACAlertPanel from './pages/Jac/JACAlertPanel';
 
 // Componentes
 import NavBar from './components/Layout/NavBar';
@@ -70,6 +71,14 @@ function App() {
                     <Route element={<RoleRoute allowedRoles={[1]} />}>
                         <Route path='/admin/users' element={<UserTable />} />
                         <Route path='/admin/roles' element={<RoleTable />} />
+                    </Route>
+
+                    {/* RUTAS JAC + ADMIN */}
+                    <Route element={<RoleRoute allowedRoles={[1, 3]} />}>
+                        <Route
+                            path='/jac/alertas'
+                            element={<JACAlertPanel />}
+                        />
                     </Route>
                 </Routes>
                 <ToastContainer position='top-right' autoClose={3000} />

--- a/src/components/Admin/AdminDashboard.tsx
+++ b/src/components/Admin/AdminDashboard.tsx
@@ -72,22 +72,27 @@ const AdminDashboard = () => {
                         </div>
                     </div>
                 </div>
-
-                {/* Tarjeta Report JAC */}
-                <div className='col-lg-4'>
-                    <div
-                        className='card shadow h-100'
-                        onClick={() => navigate('/reportes')}
-                        style={{ cursor: 'pointer' }}
-                    >
-                        <div className='card-body text-center p-5'>
-                            <i className='bi bi-people-fill fs-1 text-danger'></i>
-                            <h3 className='fw-bold text-danger'>Panel JAC</h3>
-                            <p className='text-muted'>Gestión Comunitaria</p>
+                {/* Tarjeta Panel JAC — solo Admin (1) y JAC (3) */}
+                {(rol === 1 || rol === 3) && (
+                    <div className='col-lg-4'>
+                        <div
+                            className='card shadow h-100'
+                            onClick={() => navigate('/jac/alertas')}
+                            style={{ cursor: 'pointer' }}
+                        >
+                            <div className='card-body text-center p-5'>
+                                <i className='bi bi-people-fill fs-1 text-danger'></i>
+                                <h3 className='fw-bold text-danger'>
+                                    Panel JAC
+                                </h3>
+                                <p className='text-muted'>
+                                    Gestión Comunitaria
+                                </p>
+                            </div>
                         </div>
                     </div>
-                </div>
-                {/* Admin, Ciudadano y JAC */}
+                )}
+                {/* Tarjeta Power BI */}
                 <div className='col-lg-4'>
                     <div
                         className='card shadow h-100'

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -24,6 +24,7 @@ const NavBar: React.FC = () => {
             case '/perfil':
             case '/admin':
             case '/admin/users':
+            case '/jac/alertas':
                 return '#000000';
             default:
                 return '#000000ff';
@@ -39,6 +40,7 @@ const NavBar: React.FC = () => {
 
             case '/admin':
             case '/admin/users':
+            case '/jac/alertas':
                 return '#ffffff';
 
             default:

--- a/src/hooks/useJACAlertsManager.ts
+++ b/src/hooks/useJACAlertsManager.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'react-toastify';
+import type { Alert } from '../types/Alert';
+import alertsService from '../services/alertsService';
+
+export type EstadoId = 1 | 2 | 3 | 4;
+
+export type ConfirmAction = {
+    alert: Alert;
+    nuevoEstado: EstadoId;
+    label: string;
+};
+
+export const useJACAlertsManager = (
+    onAlertUpdated?: (updated: Alert) => void,
+) => {
+    const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(
+        null,
+    );
+    const [updatingId, setUpdatingId] = useState<number | null>(null);
+
+    const requestStatusChange = useCallback(
+        (alert: Alert, nuevoEstado: EstadoId, label: string) => {
+            setConfirmAction({ alert, nuevoEstado, label });
+        },
+        [],
+    );
+
+    const cancelAction = useCallback(() => setConfirmAction(null), []);
+
+    const confirmStatusChange = useCallback(async () => {
+        if (!confirmAction) return;
+        const { alert, nuevoEstado } = confirmAction;
+        setConfirmAction(null);
+        setUpdatingId(alert.id_alerta);
+        try {
+            const updated = await alertsService.updateAlertStatus(
+                alert.id_alerta,
+                nuevoEstado,
+            );
+            toast.success('Estado actualizado correctamente');
+            onAlertUpdated?.(updated);
+        } catch (error) {
+            const msg =
+                error !== null &&
+                typeof error === 'object' &&
+                'response' in error
+                    ? ((error as { response?: { data?: { message?: string } } })
+                          .response?.data?.message ??
+                      'No se pudo actualizar el estado')
+                    : 'No se pudo actualizar el estado';
+            toast.error(msg);
+        } finally {
+            setUpdatingId(null);
+        }
+    }, [confirmAction, onAlertUpdated]);
+
+    return {
+        confirmAction,
+        updatingId,
+        requestStatusChange,
+        cancelAction,
+        confirmStatusChange,
+    };
+};

--- a/src/pages/Jac/JACAlertPanel.css
+++ b/src/pages/Jac/JACAlertPanel.css
@@ -1,0 +1,312 @@
+/* En JACAlertPanel.css — reemplaza .jac-panel-page */
+.jac-panel-page {
+    padding: 140px 32px 32px 32px; /* 90px arriba para compensar el navbar fixed */
+    /* background: #f9fafb;*/
+    min-height: 100vh;
+    max-width: 1400px; /* limita el ancho máximo */
+    margin: 0 auto; /* centra el contenido */
+}
+
+/* Stats más compactas */
+.jac-stats-grid {
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    margin-bottom: 40px;
+}
+
+.jac-stat-card {
+    background: #fff;
+    border: 1.5px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 20px 16px;
+    display: flex; /* ← flex, no column */
+    flex-direction: column; /* ← apila verticalmente */
+    align-items: center; /* ← centra horizontalmente */
+    justify-content: center; /* ← centra verticalmente */
+    gap: 8px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    width: 160px;
+    min-width: 140px;
+}
+
+.jac-stat-icon {
+    width: 40px;
+    height: 38px; /* más pequeño */
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+}
+.jac-stat-label {
+    font-size: 14px;
+    color: #9ca3af;
+    margin: 0;
+    font-weight: 500;
+    text-align: center;
+}
+.jac-stat-count {
+    font-size: 26px;
+    font-weight: 800;
+    color: #111827;
+    margin: 0;
+    line-height: 1.1;
+    text-align: center;
+}
+
+/* Card principal más compacta */
+.jac-main-card {
+    background: #fff;
+    border: 1.5px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 22px 24px; /* menos padding */
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+.jac-title {
+    font-size: 20px;
+    font-weight: 800;
+    color: #111827;
+    margin: 0 0 16px;
+}
+
+/* Filtros más compactos */
+.jac-filters {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+    align-items: center;
+}
+.jac-search-wrap {
+    position: relative;
+    flex: 1;
+    min-width: 180px;
+}
+.jac-search-icon {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #9ca3af;
+    pointer-events: none;
+    font-size: 13px;
+}
+.jac-search {
+    padding-left: 32px !important;
+    border-radius: 8px !important;
+    font-size: 13px;
+    height: 36px;
+}
+.jac-filter-select {
+    width: auto;
+    min-width: 130px;
+    border-radius: 8px !important;
+    border-color: #d1d5db !important;
+    font-size: 13px;
+    color: #374151;
+    height: 36px;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+/* Tabla más compacta */
+.jac-table-wrap {
+    overflow-x: auto;
+}
+.jac-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 750px;
+    font-size: 14px;
+}
+.jac-table thead tr {
+    border-bottom: 2px solid #f3f4f6;
+}
+.jac-table th {
+    padding: 8px 12px;
+    text-align: left;
+    font-size: 11px;
+    font-weight: 700;
+    color: #9ca3af;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+}
+.jac-table tbody tr {
+    border-bottom: 1px solid #f3f4f6;
+    transition: background 0.1s;
+}
+.jac-table tbody tr:hover {
+    background: #fafafa;
+}
+.jac-table td {
+    padding: 10px 12px;
+    color: #374151;
+    vertical-align: middle;
+}
+.jac-td-title {
+    font-weight: 600;
+    color: #111827;
+    max-width: 180px;
+}
+.jac-td-date {
+    font-size: 12px;
+    color: #9ca3af;
+    white-space: nowrap;
+}
+.jac-row-updating {
+    opacity: 0.45;
+    pointer-events: none;
+}
+.jac-empty {
+    text-align: center;
+    padding: 40px;
+    color: #9ca3af;
+    font-size: 13px;
+}
+
+/* Badge */
+.jac-badge {
+    display: inline-block;
+    padding: 2px 9px;
+    border-radius: 20px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+/* Botones acción */
+.jac-actions {
+    display: flex;
+    gap: 5px;
+}
+
+.jac-action-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border-width: 1.5px;
+    border-style: solid;
+    cursor: pointer;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+        transform 0.12s,
+        opacity 0.12s;
+}
+
+.jac-action-btn:hover:not(:disabled) {
+    transform: scale(1.15);
+}
+
+.jac-action-btn:disabled {
+    cursor: not-allowed;
+}
+
+/* Paginación */
+.jac-pagination-bar {
+    margin-top: 14px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.jac-pagination-info {
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.jac-pagination {
+    display: flex;
+    gap: 5px;
+}
+
+.jac-page-btn {
+    width: 30px;
+    height: 30px;
+    border-radius: 6px;
+    border: 1.5px solid #e5e7eb;
+    background: #fff;
+    color: #374151;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.jac-page-btn.is-active {
+    background: #111827;
+    color: #fff;
+    border-color: #111827;
+}
+.jac-page-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+/* Breadcrumb */
+.jac-breadcrumb {
+    margin-bottom: 16px;
+}
+
+/* Modal */
+.jac-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+.jac-modal {
+    background: #fff;
+    border-radius: 14px;
+    padding: 24px;
+    max-width: 360px;
+    width: 90%;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+.jac-modal-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: #111827;
+    margin: 0 0 8px;
+}
+
+.jac-modal-body {
+    color: #6b7280;
+    font-size: 13px;
+    margin: 0 0 18px;
+    line-height: 1.5;
+}
+.jac-modal-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+    .jac-stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 576px) {
+    .jac-panel-page {
+        padding: 80px 16px 24px;
+    }
+    .jac-stats-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+    .jac-filters {
+        flex-direction: column;
+    }
+    .jac-filter-select {
+        width: 100%;
+    }
+}

--- a/src/pages/Jac/JACAlertPanel.tsx
+++ b/src/pages/Jac/JACAlertPanel.tsx
@@ -1,0 +1,490 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import type { Alert } from '../../types/Alert';
+import alertsService from '../../services/alertsService';
+import {
+    useJACAlertsManager,
+    type EstadoId,
+} from '../../hooks/useJACAlertsManager';
+import { formatAlertDate } from '../../components/Alert/createAlertWorkspace.utils';
+
+import './JACAlertPanel.css';
+
+// ─── Constantes ───────
+
+const ESTADO_META: Record<
+    EstadoId,
+    { label: string; color: string; bg: string }
+> = {
+    1: { label: 'Nueva', color: '#2563eb', bg: '#eff6ff' },
+    2: { label: 'En Progreso', color: '#ec8108', bg: '#fffbeb' },
+    3: { label: 'Resuelta', color: '#16a34a', bg: '#f0fdf4' },
+    4: { label: 'Falsa Alerta', color: '#e40e0e', bg: '#fef2f2' },
+};
+
+const STATS_CONFIG = [
+    { label: 'Nuevas Alertas', id_estado: 1 as EstadoId, icon: 'bi-send' },
+    { label: 'En Progreso', id_estado: 2 as EstadoId, icon: 'bi-arrow-repeat' },
+    { label: 'Resueltas', id_estado: 3 as EstadoId, icon: 'bi-check-circle' },
+    {
+        label: 'Falsas Alertas',
+        id_estado: 4 as EstadoId,
+        icon: 'bi-exclamation-triangle',
+    },
+];
+
+const ACCIONES: {
+    nuevoEstado: EstadoId;
+    label: string;
+    icon: string;
+    title: string;
+}[] = [
+    {
+        nuevoEstado: 2,
+        label: 'En Progreso',
+        icon: 'bi-arrow-repeat',
+        title: 'Marcar En Progreso',
+    },
+    {
+        nuevoEstado: 3,
+        label: 'Resuelta',
+        icon: 'bi-check-circle',
+        title: 'Marcar Resuelta',
+    },
+    {
+        nuevoEstado: 4,
+        label: 'Falsa Alerta',
+        icon: 'bi-exclamation-triangle',
+        title: 'Marcar Falsa Alerta',
+    },
+];
+
+const PRIORIDAD_COLOR: Record<string, string> = {
+    Alta: '#dc2626',
+    Media: '#d97706',
+    Baja: '#16a34a',
+};
+
+const PAGE_SIZE = 10;
+
+// ─── Componente ──────────────
+
+const JACAlertPanel = () => {
+    const [alerts, setAlerts] = useState<Alert[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [search, setSearch] = useState('');
+    const [filtroEstado, setFiltroEstado] = useState('Todos');
+    const [filtroCategoria, setFiltroCategoria] = useState('Todas');
+    const [filtroComuna, setFiltroComuna] = useState('Todas');
+    const [currentPage, setCurrentPage] = useState(1);
+
+    const handleAlertUpdated = useCallback((updated: Alert) => {
+        setAlerts((prev) =>
+            prev.map((a) =>
+                a.id_alerta === updated.id_alerta ? { ...a, ...updated } : a,
+            ),
+        );
+    }, []);
+
+    const {
+        confirmAction,
+        updatingId,
+        requestStatusChange,
+        cancelAction,
+        confirmStatusChange,
+    } = useJACAlertsManager(handleAlertUpdated);
+
+    useEffect(() => {
+        const load = async () => {
+            setLoading(true);
+            try {
+                const data = await alertsService.list();
+                setAlerts(data);
+            } catch {
+                toast.error('No se pudieron cargar las alertas');
+            } finally {
+                setLoading(false);
+            }
+        };
+        void load();
+    }, []);
+
+    // ─── Filtrado y paginación ───────────────────────────────────
+
+    const comunasDisponibles = [
+        'Todas',
+        ...Array.from(
+            new Set(
+                alerts.map((a) => String(a.id_comuna ?? '')).filter(Boolean),
+            ),
+        ),
+    ];
+    const categoriasDisponibles = [
+        'Todas',
+        ...Array.from(new Set(alerts.map((a) => a.categoria))),
+    ];
+
+    const stats = STATS_CONFIG.map((s) => ({
+        ...s,
+        count: alerts.filter((a) => a.id_estado === s.id_estado).length,
+    }));
+
+    const filtered = alerts.filter((a) => {
+        const estadoLabel = ESTADO_META[a.id_estado as EstadoId]?.label ?? '';
+        if (filtroEstado !== 'Todos' && estadoLabel !== filtroEstado)
+            return false;
+        if (filtroCategoria !== 'Todas' && a.categoria !== filtroCategoria)
+            return false;
+        if (filtroComuna !== 'Todas' && String(a.id_comuna) !== filtroComuna)
+            return false;
+        if (search && !a.titulo.toLowerCase().includes(search.toLowerCase()))
+            return false;
+        return true;
+    });
+
+    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const paged = filtered.slice(
+        (currentPage - 1) * PAGE_SIZE,
+        currentPage * PAGE_SIZE,
+    );
+
+    const onFilterChange =
+        (setter: (v: string) => void) =>
+        (e: React.ChangeEvent<HTMLSelectElement>) => {
+            setter(e.target.value);
+            setCurrentPage(1);
+        };
+
+    // ─── Render ─────────────────────────────────────────────────
+
+    return (
+        <div className='jac-panel-page'>
+            {/* Breadcrumb */}
+            <nav aria-label='breadcrumb' className='jac-breadcrumb'>
+                <ol className='breadcrumb mb-0'>
+                    <li className='breadcrumb-item'>
+                        <Link to='/admin'>
+                            <i className='bi bi-house-door me-1' />
+                            Panel Principal
+                        </Link>
+                    </li>
+                    <li className='breadcrumb-item active' aria-current='page'>
+                        Panel JAC
+                    </li>
+                </ol>
+            </nav>
+
+            {/* Stats */}
+            <div className='jac-stats-grid'>
+                {stats.map((s) => {
+                    const meta = ESTADO_META[s.id_estado];
+                    return (
+                        <div key={s.id_estado} className='jac-stat-card'>
+                            <div
+                                className='jac-stat-icon'
+                                style={{
+                                    color: meta.color,
+                                    background: meta.bg,
+                                }}
+                            >
+                                <i className={`bi ${s.icon}`} />
+                            </div>
+                            <div>
+                                <p className='jac-stat-label'>{s.label}</p>
+                                <p className='jac-stat-count'>{s.count}</p>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* Card principal */}
+            <div className='jac-main-card'>
+                <h2 className='jac-title'>Gestión de Alertas</h2>
+
+                {/* Filtros */}
+                <div className='jac-filters'>
+                    <div className='jac-search-wrap'>
+                        <i className='bi bi-search jac-search-icon' />
+                        <input
+                            type='text'
+                            className='form-control jac-search'
+                            placeholder='Buscar por título...'
+                            value={search}
+                            onChange={(e) => {
+                                setSearch(e.target.value);
+                                setCurrentPage(1);
+                            }}
+                        />
+                    </div>
+                    <select
+                        className='form-select jac-filter-select'
+                        value={filtroEstado}
+                        onChange={onFilterChange(setFiltroEstado)}
+                    >
+                        {[
+                            'Todos',
+                            ...Object.values(ESTADO_META).map((e) => e.label),
+                        ].map((o) => (
+                            <option key={o}>{o}</option>
+                        ))}
+                    </select>
+                    <select
+                        className='form-select jac-filter-select'
+                        value={filtroCategoria}
+                        onChange={onFilterChange(setFiltroCategoria)}
+                    >
+                        {categoriasDisponibles.map((o) => (
+                            <option key={o}>{o}</option>
+                        ))}
+                    </select>
+                    <select
+                        className='form-select jac-filter-select'
+                        value={filtroComuna}
+                        onChange={onFilterChange(setFiltroComuna)}
+                    >
+                        {comunasDisponibles.map((o) => (
+                            <option key={o}>{o}</option>
+                        ))}
+                    </select>
+                </div>
+
+                {/* Tabla */}
+                <div className='jac-table-wrap'>
+                    <table className='jac-table'>
+                        <thead>
+                            <tr>
+                                <th>ALERTA</th>
+                                <th>CATEGORÍA</th>
+                                <th>INFORMANTE</th>
+                                <th>ESTADO</th>
+                                <th>PRIORIDAD</th>
+                                <th>FECHA</th>
+                                <th>ACCIONES</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {loading && (
+                                <tr>
+                                    <td colSpan={7} className='jac-empty'>
+                                        Cargando alertas...
+                                    </td>
+                                </tr>
+                            )}
+                            {!loading && paged.length === 0 && (
+                                <tr>
+                                    <td colSpan={7} className='jac-empty'>
+                                        No hay alertas que coincidan.
+                                    </td>
+                                </tr>
+                            )}
+                            {paged.map((alert) => {
+                                const meta =
+                                    ESTADO_META[alert.id_estado as EstadoId] ??
+                                    ESTADO_META[1];
+                                const isUpdating =
+                                    updatingId === alert.id_alerta;
+                                return (
+                                    <tr
+                                        key={alert.id_alerta}
+                                        className={
+                                            isUpdating ? 'jac-row-updating' : ''
+                                        }
+                                    >
+                                        <td className='jac-td-title'>
+                                            {alert.titulo}
+                                        </td>
+                                        <td>{alert.categoria}</td>
+                                        <td>
+                                            {alert.nombre_usuario ??
+                                                `Usuario #${alert.id_usuario}`}
+                                        </td>
+                                        <td>
+                                            <span
+                                                className='jac-badge'
+                                                style={{
+                                                    color: meta.color,
+                                                    background: meta.bg,
+                                                    border: `1px solid ${meta.color}44`,
+                                                }}
+                                            >
+                                                {meta.label}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <span
+                                                style={{
+                                                    fontWeight: 700,
+                                                    fontSize: 13,
+                                                    color:
+                                                        PRIORIDAD_COLOR[
+                                                            alert.prioridad ??
+                                                                ''
+                                                        ] ?? '#9ca3af',
+                                                }}
+                                            >
+                                                {alert.prioridad ?? '—'}
+                                            </span>
+                                        </td>
+                                        <td className='jac-td-date'>
+                                            {formatAlertDate(alert.created_at)}
+                                        </td>
+                                        <td>
+                                            <div className='jac-actions'>
+                                                {ACCIONES.map(
+                                                    ({
+                                                        nuevoEstado,
+                                                        label,
+                                                        icon,
+                                                        title,
+                                                    }) => {
+                                                        const accionMeta =
+                                                            ESTADO_META[
+                                                                nuevoEstado
+                                                            ];
+                                                        const yaEsEseEstado =
+                                                            alert.id_estado ===
+                                                            nuevoEstado;
+                                                        return (
+                                                            <button
+                                                                key={
+                                                                    nuevoEstado
+                                                                }
+                                                                type='button'
+                                                                className='jac-action-btn'
+                                                                title={title}
+                                                                disabled={
+                                                                    isUpdating ||
+                                                                    yaEsEseEstado
+                                                                }
+                                                                onClick={() =>
+                                                                    requestStatusChange(
+                                                                        alert,
+                                                                        nuevoEstado,
+                                                                        label,
+                                                                    )
+                                                                }
+                                                                style={{
+                                                                    borderColor:
+                                                                        accionMeta.color,
+                                                                    color: accionMeta.color,
+                                                                    background:
+                                                                        accionMeta.bg,
+                                                                    opacity:
+                                                                        yaEsEseEstado
+                                                                            ? 0.3
+                                                                            : 1,
+                                                                }}
+                                                            >
+                                                                <i
+                                                                    className={`bi ${icon}`}
+                                                                />
+                                                            </button>
+                                                        );
+                                                    },
+                                                )}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+
+                {/* Paginación */}
+                <div className='jac-pagination-bar'>
+                    <span className='jac-pagination-info'>
+                        Mostrando {paged.length} de {filtered.length} alertas
+                    </span>
+                    {totalPages > 1 && (
+                        <div className='jac-pagination'>
+                            <button
+                                type='button'
+                                className='jac-page-btn'
+                                onClick={() =>
+                                    setCurrentPage((p) => Math.max(1, p - 1))
+                                }
+                                disabled={currentPage === 1}
+                            >
+                                &lt;
+                            </button>
+                            {Array.from(
+                                { length: totalPages },
+                                (_, i) => i + 1,
+                            ).map((p) => (
+                                <button
+                                    key={p}
+                                    type='button'
+                                    className={`jac-page-btn ${p === currentPage ? 'is-active' : ''}`}
+                                    onClick={() => setCurrentPage(p)}
+                                >
+                                    {p}
+                                </button>
+                            ))}
+                            <button
+                                type='button'
+                                className='jac-page-btn'
+                                onClick={() =>
+                                    setCurrentPage((p) =>
+                                        Math.min(totalPages, p + 1),
+                                    )
+                                }
+                                disabled={currentPage === totalPages}
+                            >
+                                &gt;
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Modal de confirmación */}
+            {confirmAction && (
+                <div className='jac-modal-backdrop' onClick={cancelAction}>
+                    <div
+                        className='jac-modal'
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <h3 className='jac-modal-title'>
+                            Confirmar cambio de estado
+                        </h3>
+                        <p className='jac-modal-body'>
+                            ¿Cambiar{' '}
+                            <strong>"{confirmAction.alert.titulo}"</strong> a{' '}
+                            <strong
+                                style={{
+                                    color: ESTADO_META[
+                                        confirmAction.nuevoEstado
+                                    ].color,
+                                }}
+                            >
+                                {confirmAction.label}
+                            </strong>
+                            ?
+                        </p>
+                        <div className='jac-modal-actions'>
+                            <button
+                                type='button'
+                                className='btn btn-outline-secondary btn-sm'
+                                onClick={cancelAction}
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                type='button'
+                                className='btn btn-dark btn-sm'
+                                onClick={() => void confirmStatusChange()}
+                            >
+                                Confirmar
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default JACAlertPanel;

--- a/src/services/alertsService.ts
+++ b/src/services/alertsService.ts
@@ -1,63 +1,89 @@
-﻿import api from "./api";
-import type { Alert, CreateAlertPayload, UpdateAlertPayload } from "../types/Alert";
+﻿import api from './api';
+import type {
+    Alert,
+    CreateAlertPayload,
+    UpdateAlertPayload,
+} from '../types/Alert';
 
 const alertsService = {
-  create: async (payload: CreateAlertPayload): Promise<Alert> => {
-    const formData = new FormData();
-    formData.append("titulo", payload.titulo);
-    formData.append("descripcion", payload.descripcion);
-    formData.append("categoria", payload.categoria);
-    formData.append("id_comuna", String(payload.id_comuna));
-    formData.append("id_barrio", String(payload.id_barrio));
+    create: async (payload: CreateAlertPayload): Promise<Alert> => {
+        const formData = new FormData();
+        formData.append('titulo', payload.titulo);
+        formData.append('descripcion', payload.descripcion);
+        formData.append('categoria', payload.categoria);
+        formData.append('id_comuna', String(payload.id_comuna));
+        formData.append('id_barrio', String(payload.id_barrio));
 
-    if (payload.prioridad) formData.append("prioridad", payload.prioridad);
-    if (payload.ubicacion) formData.append("ubicacion", payload.ubicacion);
-    if (payload.evidencias?.length) {
-      payload.evidencias.forEach((file) => {
-        formData.append("evidencias", file);
-      });
-    }
+        if (payload.prioridad) formData.append('prioridad', payload.prioridad);
+        if (payload.ubicacion) formData.append('ubicacion', payload.ubicacion);
+        if (payload.evidencias?.length) {
+            payload.evidencias.forEach((file) => {
+                formData.append('evidencias', file);
+            });
+        }
 
-    const { data } = await api.post<{ message: string; alert: Alert }>(
-      "/alerts",
-      formData,
-      {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      }
-    );
-    return data.alert;
-  },
+        const { data } = await api.post<{ message: string; alert: Alert }>(
+            '/alerts',
+            formData,
+            {
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                },
+            },
+        );
+        return data.alert;
+    },
 
-  list: async (): Promise<Alert[]> => {
-    const { data } = await api.get<Alert[]>("/alerts");
-    return data;
-  },
+    list: async (): Promise<Alert[]> => {
+        const { data } = await api.get<Alert[]>('/alerts');
+        return data;
+    },
 
-  update: async (id: number, payload: UpdateAlertPayload): Promise<Alert> => {
-    const formData = new FormData();
+    update: async (id: number, payload: UpdateAlertPayload): Promise<Alert> => {
+        const formData = new FormData();
 
-    if (payload.titulo !== undefined) formData.append("titulo", payload.titulo);
-    if (payload.descripcion !== undefined) formData.append("descripcion", payload.descripcion);
-    if (payload.categoria !== undefined) formData.append("categoria", payload.categoria);
-    if (payload.prioridad !== undefined) formData.append("prioridad", payload.prioridad);
-    if (payload.id_comuna !== undefined) formData.append("id_comuna", String(payload.id_comuna));
-    if (payload.id_barrio !== undefined) formData.append("id_barrio", String(payload.id_barrio));
-    if (payload.ubicacion !== undefined) formData.append("ubicacion", payload.ubicacion);
-    if (payload.evidencias?.length) {
-      payload.evidencias.forEach((file) => {
-        formData.append("evidencias", file);
-      });
-    }
+        if (payload.titulo !== undefined)
+            formData.append('titulo', payload.titulo);
+        if (payload.descripcion !== undefined)
+            formData.append('descripcion', payload.descripcion);
+        if (payload.categoria !== undefined)
+            formData.append('categoria', payload.categoria);
+        if (payload.prioridad !== undefined)
+            formData.append('prioridad', payload.prioridad);
+        if (payload.id_comuna !== undefined)
+            formData.append('id_comuna', String(payload.id_comuna));
+        if (payload.id_barrio !== undefined)
+            formData.append('id_barrio', String(payload.id_barrio));
+        if (payload.ubicacion !== undefined)
+            formData.append('ubicacion', payload.ubicacion);
+        if (payload.evidencias?.length) {
+            payload.evidencias.forEach((file) => {
+                formData.append('evidencias', file);
+            });
+        }
 
-    const { data } = await api.put<{ message: string; alert: Alert }>(`/alerts/${id}`, formData, {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    });
-    return data.alert;
-  },
+        const { data } = await api.put<{ message: string; alert: Alert }>(
+            `/alerts/${id}`,
+            formData,
+            {
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                },
+            },
+        );
+        return data.alert;
+    },
+
+    updateAlertStatus: async (
+        idAlerta: number,
+        idEstado: number,
+    ): Promise<Alert> => {
+        const { data } = await api.patch<{ message: string; alert: Alert }>(
+            `/alerts/${idAlerta}/estado`,
+            { id_estado: idEstado },
+        );
+        return data.alert;
+    },
 };
 
 export default alertsService;


### PR DESCRIPTION
Se implementaron nuevas funcionalidades:

1. Se agrega un Panel JAC para gestionar alertas desde el frontend, incluyendo: Vista tipo dashboard con métricas por estado: Nuevas (1), En Progreso (2), Resueltas (3), Falsas Alertas (4)
2. Tabla de alertas con: título, categoría, informante (nombre_usuario), estado, prioridad y fecha
3. Filtros + búsqueda: por título, estado, categoría y comuna
4. Acciones por alerta: botones para marcar En Progreso / Resuelta / Falsa Alerta, botón deshabilitado si la alerta ya está en ese estado
5. estado “updating” por fila (bloquea acciones mientras actualiza)



**Nuevo hook useJACAlertsManager:**
* maneja modal de confirmación (confirmAction)
* maneja spinner/bloqueo por fila (updatingId)
* centraliza la lógica de llamada a alertsService.updateAlertStatus(id_alerta, nuevoEstado)

**Panel JACAlertPanel:**

- consume alertsService.list() para traer alertas
- filtra, pagina y renderiza acciones por estado
- actualiza la alerta localmente tras respuesta del backend (onAlertUpdated)


