### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,55 @@
-﻿# Digital Alert Hub - Frontend
+# Digital Alert Hub Frontend
 
-Plataforma web para gestion y visualizacion de alertas en tiempo real. Esta aplicacion esta construida con React, TypeScript y Vite, e integra autenticacion con Google, panel administrativo, gestion de alertas y modulo de reportes.
+Aplicacion web del proyecto Digital Alert Hub. Este frontend consume la API del backend para autenticacion, gestion de alertas, administracion, reportes y vistas publicas de consulta.
 
-## Caracteristicas principales
+## Estado actual
 
-- Autenticacion con Google OAuth 2.0
-- Gestion de perfil de usuario
-- Creacion, visualizacion y seguimiento de alertas
-- Dashboard administrativo
-- Modulo de reportes con filtros, graficas y mapa
-- Roles y permisos
-- Recuperacion de contrasena
-- Interfaz responsive
-- Manejo de estado global con Context API
+- Construido con React, TypeScript y Vite
+- Sesion basada en cookie `HttpOnly` emitida por el backend
+- Login con Google delegado al backend
+- Ruteo protegido por autenticacion y rol
+- Integracion con Google Maps y reCAPTCHA
+- Despliegue pensado para Vercel
+
+## Stack principal
+
+| Tecnologia | Uso |
+| --- | --- |
+| React 19 | UI |
+| TypeScript | Tipado |
+| Vite | Dev server y build |
+| React Router | Ruteo SPA |
+| Axios | Cliente HTTP |
+| Bootstrap | Base visual |
+| Recharts | Reportes y graficas |
 
 ## Requisitos previos
 
 - Node.js 18 o superior
 - npm
-- Backend ejecutandose en `http://localhost:4000`
-- Credenciales de Google OAuth
+- Backend disponible localmente o desplegado
 
-## Instalacion
+## Variables de entorno
 
-### 1. Clonar el repositorio
+El frontend ya no necesita `VITE_GOOGLE_CLIENT_ID`. El login con Google redirige al backend.
 
-```bash
-git clone https://github.com/digitalalerthub/digital-alert-hub-frontend.git
-cd digital-alert-hub-frontend
-git checkout dev
+Variables usadas actualmente:
+
+```env
+VITE_API_URL=http://localhost:4000/api
+VITE_GOOGLE_MAPS_API_KEY=tu_api_key_de_google_maps
+VITE_RECAPTCHA_SITE_KEY=tu_site_key_de_recaptcha
 ```
 
-### 2. Instalar dependencias
+Mas detalle en [docs/ENVIRONMENT.md](./docs/ENVIRONMENT.md).
+
+## Instalacion
 
 ```bash
 npm install
 ```
 
-### 3. Configurar variables de entorno
-
-Crea un archivo `.env.local` con una configuracion similar a esta:
-
-```env
-VITE_API_URL=http://localhost:4000/api
-VITE_GOOGLE_CLIENT_ID=1234567890-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com
-VITE_GOOGLE_MAPS_API_KEY=tu_api_key_de_google_maps
-VITE_RECAPTCHA_SITE_KEY=tu_site_key_de_recaptcha
-```
-
-## Scripts disponibles
+## Scripts
 
 ```bash
 npm run dev
@@ -57,9 +58,7 @@ npm run preview
 npm run lint
 ```
 
-## Ejecutar el proyecto
-
-### Desarrollo
+## Ejecucion local
 
 ```bash
 npm run dev
@@ -67,85 +66,50 @@ npm run dev
 
 La aplicacion quedara disponible en `http://localhost:5173`.
 
-### Compilar para produccion
+## Flujo de autenticacion
 
-```bash
-npm run build
-```
-
-### Vista previa de produccion
-
-```bash
-npm run preview
-```
-
-## Stack principal
-
-| Dependencia | Version | Uso |
-| --- | --- | --- |
-| react | ^19.2.0 | UI |
-| react-dom | ^19.2.0 | Renderizado |
-| react-router-dom | ^7.9.5 | Ruteo |
-| typescript | ~5.8.3 | Tipado |
-| vite | ^7.1.7 | Build y dev server |
-| axios | ^1.13.2 | Cliente HTTP |
-| recharts | ^3.8.0 | Graficas |
-| @react-oauth/google | ^0.12.2 | Login con Google |
-| react-toastify | ^11.0.5 | Notificaciones |
-| bootstrap | ^5.3.8 | Base visual |
-| bootstrap-icons | ^1.13.1 | Iconografia |
-
-## Estructura del proyecto
-
-```text
-src/
-  components/   Componentes reutilizables
-  config/       Configuracion de integraciones
-  context/      Contextos globales
-  hooks/        Hooks reutilizables
-  pages/        Pantallas principales
-  services/     Clientes HTTP y servicios
-  types/        Tipos TypeScript
-  App.tsx       Componente raiz
-  main.tsx      Punto de entrada
-```
+- El frontend usa `axios` con `withCredentials: true`
+- La sesion se hidrata con `GET /auth/session`
+- El login con Google redirige al backend en `/auth/google`
+- El callback del frontend recibe un `code` temporal y lo canjea a traves del backend
+- No se guardan tokens en `localStorage` ni `sessionStorage`
 
 ## Rutas principales
 
-| Ruta | Descripcion |
+| Ruta | Acceso |
 | --- | --- |
-| `/` | Inicio |
-| `/login` | Inicio de sesion |
-| `/register` | Registro |
-| `/callback` | Retorno de OAuth |
-| `/dashboard` | Panel principal |
-| `/profile` | Perfil |
-| `/reportes` | Reportes |
-| `/crear-alertas` | Gestion y creacion de alertas |
+| `/` | Publico |
+| `/login` | Publico |
+| `/register` | Publico |
+| `/quienes-somos` | Publico |
+| `/contacto` | Publico |
+| `/alertas/:id` | Publico |
+| `/forgot-password` | Publico |
+| `/reset-password/:token` | Publico |
+| `/auth/callback` | Publico |
+| `/admin` | Privado |
+| `/crear-alertas` | Privado |
+| `/perfil` | Privado |
+| `/perfil/cambiar-contrasena` | Privado |
+| `/admin/users` | Solo administrador |
+| `/admin/roles` | Solo administrador |
+| `/jac/alertas` | Administrador, ciudadano o JAC |
+| `/reportes` | Administrador, ciudadano o JAC |
 
-## Conexion con backend
+## Documentacion
 
-El frontend consume la API del backend mediante `VITE_API_URL`.
+La documentacion tecnica del frontend queda centralizada en [docs/README.md](./docs/README.md).
 
-Puntos clave:
+Para la documentacion del backend y flujos compartidos:
 
-- Axios base en `src/services/api.ts`
-- Token JWT enviado en `Authorization: Bearer <token>`
-- Integracion con autenticacion de Google
-- Integracion con Google Maps para mapas y geocodificacion
-
-## Notas
-
-- Para login con Google debes configurar correctamente el `VITE_GOOGLE_CLIENT_ID`.
-- Para mapas y geocodificacion debes configurar `VITE_GOOGLE_MAPS_API_KEY`.
-- El backend debe estar disponible antes de levantar el frontend.
+- [../digital-alert-hub-backend/README.md](../digital-alert-hub-backend/README.md)
+- [../digital-alert-hub-backend/docs/README.md](../digital-alert-hub-backend/docs/README.md)
 
 ## Contribucion
 
 1. Crear una rama desde `dev`
-2. Realizar cambios y commits
-3. Subir la rama al remoto
-4. Abrir Pull Request hacia `dev`
+2. Realizar cambios y pruebas
+3. Abrir Pull Request con contexto funcional y tecnico
 
 ## Licencia
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,58 @@
+# Variables de Entorno
+
+## Variables vigentes
+
+### `VITE_API_URL`
+
+Base URL de la API backend.
+
+Ejemplo local:
+
+```env
+VITE_API_URL=http://localhost:4000/api
+```
+
+Uso:
+
+- configuracion base de Axios
+- inicio del flujo OAuth Google
+- llamadas de autenticacion y datos
+
+### `VITE_GOOGLE_MAPS_API_KEY`
+
+API key usada por los modulos que cargan Google Maps.
+
+Ejemplo:
+
+```env
+VITE_GOOGLE_MAPS_API_KEY=tu_api_key
+```
+
+### `VITE_RECAPTCHA_SITE_KEY`
+
+Clave publica de reCAPTCHA para formularios que la requieran.
+
+Ejemplo:
+
+```env
+VITE_RECAPTCHA_SITE_KEY=tu_site_key
+```
+
+## Variables que ya no aplican
+
+### `VITE_GOOGLE_CLIENT_ID`
+
+Ya no es necesaria en el frontend actual. El flujo de Google se inicia contra el backend, que es quien orquesta OAuth.
+
+## Recomendaciones por entorno
+
+### Desarrollo local
+
+- `VITE_API_URL` debe apuntar al backend local o al ambiente de pruebas habilitado para CORS.
+- Si se usa login con Google, la URL del frontend debe coincidir con las permitidas en el proveedor y en backend.
+
+### Produccion
+
+- `VITE_API_URL` debe apuntar a la API publica real.
+- La CSP de [`vercel.json`](../vercel.json) debe seguir alineada con los dominios externos realmente usados.
+- No documentar ni exponer secretos privados del backend en variables `VITE_*`.

--- a/docs/FRONTEND_SECURITY.md
+++ b/docs/FRONTEND_SECURITY.md
@@ -1,0 +1,78 @@
+# Seguridad del Frontend
+
+## Resumen ejecutivo
+
+El frontend de Digital Alert Hub ya no depende de almacenamiento de tokens en el navegador y opera con una sesion basada en cookie `HttpOnly` administrada por el backend. La postura actual reduce los riesgos de robo de token por XSS, exposicion de JWT en URLs y redirecciones inseguras posteriores al login.
+
+## Controles implementados
+
+### 1. Sesion por cookie `HttpOnly`
+
+- El cliente HTTP usa `withCredentials: true` en [`src/services/api.ts`](../src/services/api.ts).
+- La aplicacion no persiste tokens en `localStorage` ni `sessionStorage`.
+- La sesion se hidrata con `GET /auth/session` desde [`src/context/AuthProvider.tsx`](../src/context/AuthProvider.tsx).
+
+Impacto:
+
+- Reduce el acceso del JavaScript del navegador a credenciales de sesion.
+- Disminuye el impacto de un XSS respecto al modelo anterior basado en `localStorage`.
+
+### 2. Login con Google sin JWT en URL
+
+- El boton de Google redirige al backend en [`src/components/Auth/GoogleButton.tsx`](../src/components/Auth/GoogleButton.tsx).
+- El callback del frontend trabaja con un `code` temporal y no con un token persistente.
+
+Impacto:
+
+- Evita exponer JWT en historial del navegador, logs, analytics o `Referer`.
+
+### 3. Saneamiento de redirecciones internas
+
+- El helper [`src/utils/navigation.ts`](../src/utils/navigation.ts) limita `redirect` a rutas internas validas.
+
+Impacto:
+
+- Reduce superficie para open redirect y redirecciones ambiguas tras login o registro.
+
+### 4. Headers de seguridad en despliegue
+
+- [`vercel.json`](../vercel.json) define:
+  - `Content-Security-Policy`
+  - `Referrer-Policy`
+  - `X-Content-Type-Options`
+  - `X-Frame-Options`
+  - `Permissions-Policy`
+
+Impacto:
+
+- Restringe carga de recursos a origenes conocidos.
+- Dificulta clickjacking y sniffing de contenido.
+- Reduce fuga de contexto entre sitios.
+
+### 5. Rutas protegidas en cliente
+
+- [`src/components/Route/PrivateRoute.tsx`](../src/components/Route/PrivateRoute.tsx) protege vistas autenticadas.
+- [`src/components/Route/RoleRoute.tsx`](../src/components/Route/RoleRoute.tsx) protege vistas por rol.
+
+Impacto:
+
+- Mejora experiencia de usuario y reduce exposicion accidental de vistas sensibles.
+- No reemplaza controles de autorizacion del backend.
+
+## Decisiones de seguridad relevantes
+
+- El frontend asume que la autorizacion real vive en backend.
+- La cookie de sesion debe seguir siendo emitida y revocada por la API.
+- Los proveedores externos autorizados actualmente incluyen Google Maps y reCAPTCHA; cualquier nuevo proveedor debe reflejarse en CSP antes de desplegar.
+
+## Riesgos residuales
+
+- La CSP del frontend permite recursos externos necesarios. Si se agrega una nueva integracion sin revisar la politica, se puede abrir superficie innecesaria.
+- Las protecciones de rutas en frontend no sustituyen validacion de permisos en backend.
+- Un XSS futuro seguiria siendo grave aunque el impacto sea menor que con tokens en `localStorage`.
+
+## Recomendaciones operativas
+
+- Mantener `vercel.json` alineado con los dominios reales consumidos por la aplicacion.
+- Revisar cambios en autenticacion junto con el backend, no de forma aislada.
+- Validar en cada release que el frontend siga funcionando sin depender de tokens en JS.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentacion Frontend
+
+Esta carpeta centraliza la documentacion tecnica vigente del frontend de Digital Alert Hub.
+
+## Documentos disponibles
+
+- [FRONTEND_SECURITY.md](./FRONTEND_SECURITY.md): postura de seguridad del frontend, controles implementados y riesgos residuales.
+- [ROUTING_AND_AUTH.md](./ROUTING_AND_AUTH.md): arquitectura de autenticacion, hidratacion de sesion y reglas de acceso por ruta.
+- [ENVIRONMENT.md](./ENVIRONMENT.md): variables de entorno y consideraciones por entorno.
+
+## Uso recomendado
+
+- Usa el `README.md` de la raiz para presentacion general del proyecto.
+- Usa esta carpeta como fuente canonica para decisiones tecnicas del frontend.
+- Cuando cambie el flujo de autenticacion, despliegue o seguridad, actualiza primero estos documentos.
+
+## Documentacion complementaria del backend
+
+- [../../digital-alert-hub-backend/README.md](../../digital-alert-hub-backend/README.md): presentacion y contexto general del backend.
+- [../../digital-alert-hub-backend/docs/README.md](../../digital-alert-hub-backend/docs/README.md): indice tecnico del backend, seguridad, despliegue, reportes y activacion de cuenta.
+- [../../digital-alert-hub-backend/docs/TESTING_GUIDE.md](../../digital-alert-hub-backend/docs/TESTING_GUIDE.md): guia consolidada de pruebas del proyecto, incluyendo backend y frontend.

--- a/docs/ROUTING_AND_AUTH.md
+++ b/docs/ROUTING_AND_AUTH.md
@@ -1,0 +1,88 @@
+# Routing y Autenticacion
+
+## Arquitectura general
+
+La aplicacion usa `BrowserRouter` y centraliza el estado de autenticacion en [`src/context/AuthProvider.tsx`](../src/context/AuthProvider.tsx). El proveedor no guarda credenciales; solo mantiene el estado derivado de la sesion actual.
+
+## Hidratacion de sesion
+
+Al iniciar la aplicacion:
+
+1. `AuthProvider` ejecuta `GET /auth/session`
+2. Si la API responde con usuario valido, se marca la sesion como autenticada
+3. Si falla, el estado queda anonimo
+
+Esto permite que un refresh del navegador mantenga la sesion si la cookie sigue vigente.
+
+## Login
+
+### Login tradicional
+
+- El formulario autentica contra backend.
+- Despues del login, `AuthProvider.login()` vuelve a sincronizar la sesion actual.
+
+### Login con Google
+
+- [`src/components/Auth/GoogleButton.tsx`](../src/components/Auth/GoogleButton.tsx) redirige a `${VITE_API_URL}/auth/google`
+- El backend gestiona OAuth y redirige al frontend en `/auth/callback`
+- El callback canjea un `code` temporal y luego rehidrata sesion
+
+## Logout
+
+- `AuthProvider.logout()` invoca `POST /auth/logout`
+- Luego limpia el estado local
+- La revocacion efectiva de la sesion ocurre en backend
+
+## Rutas publicas
+
+- `/`
+- `/login`
+- `/register`
+- `/quienes-somos`
+- `/contacto`
+- `/alertas/:id`
+- `/forgot-password`
+- `/reset-password/:token`
+- `/auth/callback`
+
+## Rutas privadas
+
+Protegidas por [`src/components/Route/PrivateRoute.tsx`](../src/components/Route/PrivateRoute.tsx):
+
+- `/admin`
+- `/crear-alertas`
+- `/perfil`
+- `/perfil/cambiar-contrasena`
+
+Comportamiento:
+
+- Mientras `isLoading` esta activo, no renderiza la vista protegida
+- Si no hay sesion, redirige a `/`
+
+## Rutas por rol
+
+Protegidas por [`src/components/Route/RoleRoute.tsx`](../src/components/Route/RoleRoute.tsx):
+
+### Solo administrador
+
+- `/admin/users`
+- `/admin/roles`
+
+### Administrador, ciudadano o JAC
+
+- `/jac/alertas`
+- `/reportes`
+
+Comportamiento:
+
+- Si no hay sesion, redirige a `/`
+- Si el rol no esta permitido, redirige a `/admin`
+
+## Consideraciones para el equipo
+
+- Si cambian rutas privadas o por rol, actualizar este documento y `App.tsx`.
+- Si cambia el flujo de sesion, revisar en conjunto:
+  - `AuthProvider.tsx`
+  - `api.ts`
+  - `Callback.tsx`
+  - rutas protegidas

--- a/src/components/Alert/AlertDetailModal.tsx
+++ b/src/components/Alert/AlertDetailModal.tsx
@@ -317,8 +317,9 @@ const AlertDetailModal = ({
       if (editingCommentId === commentId) {
         cancelEditComment();
       }
+      toast.success("Comentario eliminado correctamente");
     } catch {
-      // No bloqueamos UI por errores de red.
+      toast.error("No se pudo eliminar el comentario");
     } finally {
       setDeletingCommentId(null);
     }

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import "../../App.css";
 import { getRecaptchaToken, isRecaptchaEnabled } from "../../config/recaptcha";
 import { useAuth } from "../../context/useAuth";
 import api from "../../services/api";
+import { sanitizeInternalRedirect } from "../../utils/navigation";
 import GoogleButton from "./GoogleButton";
 
 const LoginForm = () => {
@@ -16,8 +17,10 @@ const LoginForm = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { login } = useAuth();
-  const redirectTo =
-    new URLSearchParams(location.search).get("redirect") || "/admin";
+  const redirectTo = sanitizeInternalRedirect(
+    new URLSearchParams(location.search).get("redirect"),
+    "/admin"
+  );
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -51,12 +54,12 @@ const LoginForm = () => {
         ? await getRecaptchaToken("login")
         : null;
 
-      const res = await api.post("/auth/login", {
+      await api.post("/auth/login", {
         email,
         contrasena,
         captchaToken,
       });
-      login(res.data.token);
+      await login();
 
       toast.success("Inicio de sesión exitoso");
       setTimeout(() => navigate(redirectTo, { replace: true }), 800);

--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -6,6 +6,7 @@ import { toast } from "react-toastify";
 import "../../App.css";
 import { getRecaptchaToken, isRecaptchaEnabled } from "../../config/recaptcha";
 import api from "../../services/api";
+import { sanitizeInternalRedirect } from "../../utils/navigation";
 import GoogleButton from "./GoogleButton";
 
 const NAME_REGEX = /^[A-Za-zÁÉÍÓÚáéíóúÑñÜü\s'-]{2,100}$/;
@@ -22,7 +23,10 @@ const RegisterForm = () => {
 
   const navigate = useNavigate();
   const location = useLocation();
-  const redirectTo = new URLSearchParams(location.search).get("redirect");
+  const redirectTo = sanitizeInternalRedirect(
+    new URLSearchParams(location.search).get("redirect"),
+    ""
+  );
   const loginUrl = redirectTo
     ? `/login?redirect=${encodeURIComponent(redirectTo)}`
     : "/login";

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -59,10 +59,10 @@ const NavBar: React.FC = () => {
     navigate(path);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     closeMobileMenu();
     closeDesktopMenu();
-    logout();
+    await logout();
     navigate("/");
   };
 

--- a/src/components/Profile/DeleteAccount.tsx
+++ b/src/components/Profile/DeleteAccount.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { useAuth } from '../../context/useAuth';
 import { deleteAccount } from '../../services/profileService';
 
 export default function DeleteAccount() {
     const [showModal, setShowModal] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const navigate = useNavigate();
+    const { logout } = useAuth();
 
     const handleDelete = async () => {
         try {
@@ -18,8 +20,7 @@ export default function DeleteAccount() {
                     autoClose: 2000,
                 });
 
-                localStorage.removeItem('token');
-                localStorage.removeItem('user');
+                await logout();
 
                 setTimeout(() => {
                     navigate('/login');

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,8 +8,10 @@ export interface JWTPayload {
     email: string;
     rol: number;
     role_name?: CanonicalRoleName | null;
-    exp: number;
+    exp?: number;
 }
+
+export type AuthUser = JWTPayload;
 
 export interface AuthContextType {
     isLoggedIn: boolean;
@@ -17,8 +19,8 @@ export interface AuthContextType {
     user: JWTPayload | null;
     isAdmin: boolean;
     token: string | null;
-    login: (token: string) => void;
-    logout: () => void;
+    login: () => Promise<void>;
+    logout: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,62 +1,67 @@
-// Controla el manejo global de autenticación
-
-import { useState, useEffect, type ReactNode } from 'react';
-import { jwtDecode } from 'jwt-decode';
+import { useEffect, useState, type ReactNode } from 'react';
+import api from '../services/api';
 import { AuthContext } from './AuthContext';
-import type { JWTPayload } from './AuthContext';
+import type { AuthUser } from './AuthContext';
 import { getCanonicalRoleName, isAdminRole } from '../utils/roles';
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-    const [user, setUser] = useState<JWTPayload | null>(null);
+    const [user, setUser] = useState<AuthUser | null>(null);
     const [token, setToken] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
-    const decodeToken = (rawToken: string): JWTPayload => {
-        const decoded = jwtDecode<JWTPayload>(rawToken);
+    const normalizeUser = (rawUser: unknown): AuthUser | null => {
+        if (!rawUser || typeof rawUser !== 'object') return null;
+
+        const candidate = rawUser as Record<string, unknown>;
+        const id = Number(candidate.id);
+        const rol = Number(candidate.rol);
+        const email =
+            typeof candidate.email === 'string' ? candidate.email.trim() : '';
+        const roleName = getCanonicalRoleName(candidate.role_name);
+
+        if (!Number.isInteger(id) || id <= 0) return null;
+        if (!Number.isInteger(rol) || rol <= 0) return null;
+        if (!email) return null;
 
         return {
-            ...decoded,
-            role_name: getCanonicalRoleName(decoded.role_name),
+            id,
+            email,
+            rol,
+            role_name: roleName,
         };
     };
 
-    const isTokenExpired = (token: string): boolean => {
+    const syncSession = async () => {
         try {
-            const decoded = decodeToken(token);
-            const now = Math.floor(Date.now() / 1000);
-            return decoded.exp < now;
+            const response = await api.get('/auth/session');
+            setUser(normalizeUser(response.data?.user));
+            setToken(null);
         } catch {
-            return true;
+            setUser(null);
+            setToken(null);
         }
     };
 
     useEffect(() => {
-        const savedToken = localStorage.getItem('token');
+        const bootstrapSession = async () => {
+            await syncSession();
+            setIsLoading(false);
+        };
 
-        if (savedToken && !isTokenExpired(savedToken)) {
-            try {
-                const decoded = decodeToken(savedToken);
-                setUser(decoded);
-                setToken(savedToken);
-            } catch {
-                localStorage.removeItem('token');
-            }
-        } else {
-            localStorage.removeItem('token');
-        }
-
-        setIsLoading(false);
+        void bootstrapSession();
     }, []);
 
-    const login = (newToken: string) => {
-        localStorage.setItem('token', newToken);
-        const decoded = decodeToken(newToken);
-        setUser(decoded);
-        setToken(newToken);
+    const login = async () => {
+        await syncSession();
     };
 
-    const logout = () => {
-        localStorage.removeItem('token');
+    const logout = async () => {
+        try {
+            await api.post('/auth/logout');
+        } catch {
+            // Limpiamos el estado local incluso si la limpieza remota falla.
+        }
+
         setUser(null);
         setToken(null);
     };

--- a/src/pages/Auth/Callback.test.tsx
+++ b/src/pages/Auth/Callback.test.tsx
@@ -1,0 +1,109 @@
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../context/useAuth';
+import api from '../../services/api';
+import Callback from './Callback';
+
+const mockedNavigate = vi.fn();
+
+vi.mock('../../context/useAuth', () => ({
+    useAuth: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+    default: {
+        post: vi.fn(),
+    },
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>(
+        'react-router-dom',
+    );
+
+    return {
+        ...actual,
+        useNavigate: () => mockedNavigate,
+    };
+});
+
+const mockedUseAuth = vi.mocked(useAuth);
+
+const buildTree = (initialEntry = '/auth/callback?code=test-google-code') => (
+    <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+            <Route path='/auth/callback' element={<Callback />} />
+        </Routes>
+    </MemoryRouter>
+);
+
+const renderCallback = (initialEntry = '/auth/callback?code=test-google-code') => {
+    const tree = buildTree(initialEntry);
+
+    return {
+        initialEntry,
+        ...render(tree),
+    };
+};
+
+describe('Callback', () => {
+    let authState: ReturnType<typeof mockedUseAuth>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(api.post).mockResolvedValue({
+            data: { message: 'Sesion iniciada correctamente' },
+        });
+        authState = {
+            isLoggedIn: false,
+            isLoading: true,
+            user: null,
+            isAdmin: false,
+            token: null,
+            login: vi.fn(),
+            logout: vi.fn(),
+        };
+        mockedUseAuth.mockImplementation(() => authState);
+    });
+
+    it('actualiza el contexto antes de redirigir al panel principal', async () => {
+        const view = renderCallback();
+
+        await waitFor(() => {
+            expect(api.post).toHaveBeenCalledWith('/auth/google/exchange', {
+                code: 'test-google-code',
+            });
+        });
+        await waitFor(() => {
+            expect(authState.login).toHaveBeenCalledTimes(1);
+        });
+        expect(mockedNavigate).not.toHaveBeenCalled();
+
+        authState = {
+            ...authState,
+            isLoggedIn: true,
+            isLoading: false,
+            token: null,
+        };
+
+        view.rerender(buildTree(view.initialEntry));
+
+        await waitFor(() => {
+            expect(mockedNavigate).toHaveBeenCalledWith('/admin', {
+                replace: true,
+            });
+        });
+    });
+
+    it('redirige al inicio cuando no llega codigo en el callback', async () => {
+        renderCallback('/auth/callback');
+
+        await waitFor(() => {
+            expect(mockedNavigate).toHaveBeenCalledWith('/', {
+                replace: true,
+            });
+        });
+        expect(authState.login).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/Auth/Callback.tsx
+++ b/src/pages/Auth/Callback.tsx
@@ -1,21 +1,41 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../context/useAuth';
+import api from '../../services/api';
 
 function Callback() {
-    const [searchParams] = useSearchParams();
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const { isLoggedIn, isLoading, login } = useAuth();
+    const [handledExchange, setHandledExchange] = useState(false);
+    const code = searchParams.get('code');
 
     useEffect(() => {
-        const token = searchParams.get('token');
-
-        if (token) {
-            localStorage.setItem('token', token);
-            navigate('/admin', { replace: true });
+        if (!code) {
+            navigate('/', { replace: true });
             return;
         }
 
-        navigate('/', { replace: true });
-    }, [navigate, searchParams]);
+        if (handledExchange) return;
+
+        const exchangeCode = async () => {
+            try {
+                await api.post('/auth/google/exchange', { code });
+                await login();
+                setHandledExchange(true);
+            } catch {
+                navigate('/', { replace: true });
+            }
+        };
+
+        void exchangeCode();
+    }, [code, handledExchange, login, navigate]);
+
+    useEffect(() => {
+        if (!handledExchange || isLoading) return;
+
+        navigate(isLoggedIn ? '/admin' : '/', { replace: true });
+    }, [handledExchange, isLoading, isLoggedIn, navigate]);
 
     return (
         <div

--- a/src/pages/Profile/ChangePasswordPage.tsx
+++ b/src/pages/Profile/ChangePasswordPage.tsx
@@ -6,8 +6,8 @@ export default function ChangePasswordPage() {
     const navigate = useNavigate();
     const { logout } = useAuth();
 
-    const handleSuccess = () => {
-        logout();
+    const handleSuccess = async () => {
+        await logout();
         navigate('/login');
     };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,22 +4,10 @@ const API_URL = import.meta.env.VITE_API_URL || "http://localhost:4000/api";
 
 const api = axios.create({
   baseURL: API_URL,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },
 });
-
-api.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem("token");
-
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
 
 export default api;

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeInternalRedirect } from "./navigation";
+
+describe("sanitizeInternalRedirect", () => {
+  it("acepta rutas internas validas", () => {
+    expect(sanitizeInternalRedirect("/reportes?year=2026#tabla")).toBe(
+      "/reportes?year=2026#tabla"
+    );
+  });
+
+  it("usa el fallback cuando no recibe una ruta", () => {
+    expect(sanitizeInternalRedirect(null)).toBe("/admin");
+    expect(sanitizeInternalRedirect("")).toBe("/admin");
+    expect(sanitizeInternalRedirect("   ")).toBe("/admin");
+  });
+
+  it("rechaza redirects externos o ambiguos", () => {
+    expect(sanitizeInternalRedirect("https://evil.example")).toBe("/admin");
+    expect(sanitizeInternalRedirect("//evil.example")).toBe("/admin");
+    expect(sanitizeInternalRedirect("javascript:alert(1)")).toBe("/admin");
+  });
+
+  it("rechaza rutas con backslashes o saltos de linea", () => {
+    expect(sanitizeInternalRedirect("/\\evil")).toBe("/admin");
+    expect(sanitizeInternalRedirect("/admin\r\nLocation: /evil")).toBe("/admin");
+  });
+});

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,17 @@
+export const sanitizeInternalRedirect = (
+  value: string | null | undefined,
+  fallback = "/admin"
+): string => {
+  if (typeof value !== "string") return fallback;
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return fallback;
+
+  // Solo permitimos rutas absolutas internas del SPA.
+  if (!trimmedValue.startsWith("/")) return fallback;
+  if (trimmedValue.startsWith("//")) return fallback;
+  if (trimmedValue.includes("\\")) return fallback;
+  if (/[\r\n]/.test(trimmedValue)) return fallback;
+
+  return trimmedValue;
+};

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,31 @@
   "framework": "vite",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://www.google.com https://www.gstatic.com https://maps.googleapis.com https://maps.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: http://localhost:* ws://localhost:*; media-src 'self' blob: https:; frame-src 'self' https://www.google.com https://www.google.com/recaptcha/ https://www.google.com/maps/embed; worker-src 'self' blob:;"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(self)"
+        }
+      ]
+    },
+    {
       "source": "/dist/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Qué cambia

- Migra el frontend al modelo de sesión por cookie `HttpOnly`
- Hidrata sesión con `/auth/session`
- Ajusta el callback OAuth para trabajar con `code`
- Sanea redirects internos
- Añade headers/CSP en `vercel.json`
- Agrega documentación técnica del frontend en `docs/`
- Añade feedback visual al eliminar comentarios

Incluye

- pruebas para callback OAuth y saneamiento de navegación
- documentación de seguridad, routing/auth y variables de entorno