### PR TITLE
Dev

### DIFF
--- a/src/config/recaptcha.ts
+++ b/src/config/recaptcha.ts
@@ -62,7 +62,12 @@ const loadRecaptchaScript = (): Promise<void> => {
 };
 
 export const getRecaptchaToken = async (
-  action: "login" | "register"
+  action:
+    | "login"
+    | "register"
+    | "forgot_password"
+    | "password_reset"
+    | "set_password"
 ): Promise<string | null> => {
   if (!isRecaptchaEnabled) {
     return null;

--- a/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/src/pages/Auth/ForgotPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import api from "../../services/api";
 import { toast } from "react-toastify";
+import { getRecaptchaToken, isRecaptchaEnabled } from "../../config/recaptcha";
 
 const ForgotPasswordPage = () => {
   const [email, setEmail] = useState("");
@@ -12,7 +13,10 @@ const ForgotPasswordPage = () => {
     setIsLoading(true); // Cargando en el botón Enviar
 
     try {
-      await api.post("/auth/forgot-password", { email });
+      const captchaToken = isRecaptchaEnabled
+        ? await getRecaptchaToken("forgot_password")
+        : null;
+      await api.post("/auth/forgot-password", { email, captchaToken });
       setEmailSent(true);
       toast.success("Te enviamos un enlace para restablecer tu contraseña.");
     } catch {

--- a/src/pages/Auth/ResetPasswordPage.test.tsx
+++ b/src/pages/Auth/ResetPasswordPage.test.tsx
@@ -3,14 +3,22 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import api from '../../services/api';
+import { getRecaptchaToken } from '../../config/recaptcha';
+import { toast } from 'react-toastify';
 import ResetPasswordPage from './ResetPasswordPage';
 
 const mockedNavigate = vi.fn();
 
 vi.mock('../../services/api', () => ({
     default: {
+        get: vi.fn(),
         post: vi.fn(),
     },
+}));
+
+vi.mock('../../config/recaptcha', () => ({
+    getRecaptchaToken: vi.fn(),
+    isRecaptchaEnabled: true,
 }));
 
 vi.mock('react-toastify', () => ({
@@ -46,6 +54,8 @@ const renderResetPasswordPage = (initialEntry: string) =>
 describe('ResetPasswordPage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(api.get).mockResolvedValue({ data: { message: 'Token valido' } });
+        vi.mocked(getRecaptchaToken).mockResolvedValue('captcha-token');
     });
 
     it('muestra errores y no envia si la contrasena es invalida', async () => {
@@ -53,6 +63,7 @@ describe('ResetPasswordPage', () => {
 
         renderResetPasswordPage('/reset-password/token123?mode=activation');
 
+        await screen.findByPlaceholderText('Nueva Contrasena');
         await user.type(
             screen.getByPlaceholderText('Nueva Contrasena'),
             '12345678',
@@ -79,6 +90,7 @@ describe('ResetPasswordPage', () => {
 
         renderResetPasswordPage('/reset-password/token123');
 
+        await screen.findByPlaceholderText('Nueva Contrasena');
         await user.type(
             screen.getByPlaceholderText('Nueva Contrasena'),
             'Clave1234',
@@ -93,7 +105,31 @@ describe('ResetPasswordPage', () => {
 
         expect(api.post).toHaveBeenCalledWith('/auth/reset-password/token123', {
             nuevaContrasena: 'Clave1234',
+            captchaToken: 'captcha-token',
         });
         expect(mockedNavigate).toHaveBeenCalledWith('/login');
+    });
+
+    it('muestra un estado invalido cuando el token ya fue usado', async () => {
+        vi.mocked(api.get).mockRejectedValue({
+            response: {
+                data: {
+                    message:
+                        'Este enlace ya fue usado o fue reemplazado por uno mas reciente',
+                },
+            },
+            isAxiosError: true,
+        });
+
+        renderResetPasswordPage('/reset-password/token123');
+
+        await screen.findByText('Validando enlace');
+
+        await vi.waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith(
+                'Este enlace ya fue usado o fue reemplazado por uno mas reciente',
+            );
+            expect(mockedNavigate).toHaveBeenCalledWith('/login');
+        });
     });
 });

--- a/src/pages/Auth/ResetPasswordPage.tsx
+++ b/src/pages/Auth/ResetPasswordPage.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import axios from "axios";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import api from "../../services/api";
+import { getRecaptchaToken, isRecaptchaEnabled } from "../../config/recaptcha";
 import { validatePassword } from "../../utils/userValidation";
 
 const ResetPasswordPage = () => {
@@ -10,10 +12,54 @@ const ResetPasswordPage = () => {
   const [searchParams] = useSearchParams();
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [isCheckingToken, setIsCheckingToken] = useState(true);
   const [errors, setErrors] = useState<{ password?: string; confirmPassword?: string }>(
     {}
   );
   const isActivationMode = searchParams.get("mode") === "activation";
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const validateToken = async () => {
+      if (!token) {
+        if (isMounted) {
+          toast.error("El enlace es invalido o expiro.");
+          navigate("/login");
+          setIsCheckingToken(false);
+        }
+        return;
+      }
+
+      try {
+        await api.get(`/auth/reset-password/${token}`);
+
+        if (isMounted) {
+          setIsCheckingToken(false);
+        }
+      } catch (error) {
+        const message = axios.isAxiosError(error)
+          ? error.response?.data?.message
+          : null;
+
+        if (isMounted) {
+          toast.error(
+            typeof message === "string"
+              ? message
+              : "El enlace es invalido o expiro."
+          );
+          navigate("/login");
+          setIsCheckingToken(false);
+        }
+      }
+    };
+
+    void validateToken();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [navigate, token]);
 
   const validateForm = (): { isValid: boolean; firstError: string | null } => {
     const nextErrors: { password?: string; confirmPassword?: string } = {};
@@ -50,8 +96,15 @@ const ResetPasswordPage = () => {
     }
 
     try {
+      const captchaToken = isRecaptchaEnabled
+        ? await getRecaptchaToken(
+            isActivationMode ? "set_password" : "password_reset"
+          )
+        : null;
+
       await api.post(`/auth/reset-password/${token}`, {
         nuevaContrasena: password.trim(),
+        captchaToken,
       });
 
       toast.success(
@@ -64,6 +117,23 @@ const ResetPasswordPage = () => {
       toast.error("Error al restablecer la contrasena, intentalo nuevamente");
     }
   };
+
+  if (isCheckingToken) {
+    return (
+      <div className="login-background d-flex justify-content-center align-items-center vh-100 bg-light">
+        <div
+          className="card shadow p-4 text-center"
+          style={{ width: "360px", borderRadius: "15px" }}
+        >
+          <div className="spinner-border text-primary mx-auto mb-3" role="status" />
+          <h3 className="fw-bold mb-2">Validando enlace</h3>
+          <p className="text-muted mb-0">
+            Estamos verificando que el enlace siga disponible.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="login-background d-flex justify-content-center align-items-center vh-100 bg-light">


### PR DESCRIPTION
Este PR corrige el flujo de recuperación y restablecimiento de contraseña en el frontend.

## Cambios principales
- Se agrega envío de `captchaToken` en `forgot-password`
- Se agrega envío de `captchaToken` en `reset-password`
- Se amplía `getRecaptchaToken` para soportar las acciones:
  - `forgot_password`
  - `password_reset`
  - `set_password`
- La pantalla de restablecer contraseña ahora valida el token al cargar
- Si el enlace es inválido, expiró o ya fue usado:
  - se muestra un toast con el mensaje correspondiente
  - se redirige al login
- Se actualizan las pruebas del flujo de reset para cubrir:
  - envío de `captchaToken`
  - redirección por token inválido/usado
