### PR TITLE
fix(auth): add mobile token fallback

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -54,12 +54,14 @@ const LoginForm = () => {
         ? await getRecaptchaToken("login")
         : null;
 
-      await api.post("/auth/login", {
+      const response = await api.post("/auth/login", {
         email,
         contrasena,
         captchaToken,
       });
-      await login();
+      const token =
+        typeof response.data?.token === "string" ? response.data.token : null;
+      await login(token);
 
       toast.success("Inicio de sesión exitoso");
       setTimeout(() => navigate(redirectTo, { replace: true }), 800);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -19,7 +19,7 @@ export interface AuthContextType {
     user: JWTPayload | null;
     isAdmin: boolean;
     token: string | null;
-    login: () => Promise<void>;
+    login: (token?: string | null) => Promise<void>;
     logout: () => Promise<void>;
 }
 

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -4,6 +4,8 @@ import { AuthContext } from './AuthContext';
 import type { AuthUser } from './AuthContext';
 import { getCanonicalRoleName, isAdminRole } from '../utils/roles';
 
+const AUTH_TOKEN_STORAGE_KEY = 'token';
+
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<AuthUser | null>(null);
     const [token, setToken] = useState<string | null>(null);
@@ -31,19 +33,34 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         };
     };
 
-    const syncSession = async () => {
+    const persistToken = (nextToken: string | null) => {
+        if (nextToken) {
+            window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, nextToken);
+        } else {
+            window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+        }
+
+        setToken(nextToken);
+    };
+
+    const syncSession = async (nextToken?: string | null) => {
+        if (nextToken !== undefined) {
+            persistToken(nextToken);
+        }
+
         try {
             const response = await api.get('/auth/session');
             setUser(normalizeUser(response.data?.user));
-            setToken(null);
         } catch {
             setUser(null);
-            setToken(null);
+            persistToken(null);
         }
     };
 
     useEffect(() => {
         const bootstrapSession = async () => {
+            const savedToken = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+            setToken(savedToken);
             await syncSession();
             setIsLoading(false);
         };
@@ -51,8 +68,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         void bootstrapSession();
     }, []);
 
-    const login = async () => {
-        await syncSession();
+    const login = async (nextToken?: string | null) => {
+        await syncSession(nextToken);
     };
 
     const logout = async () => {
@@ -63,7 +80,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
 
         setUser(null);
-        setToken(null);
+        persistToken(null);
     };
 
     return (

--- a/src/pages/Auth/Callback.test.tsx
+++ b/src/pages/Auth/Callback.test.tsx
@@ -53,7 +53,10 @@ describe('Callback', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(api.post).mockResolvedValue({
-            data: { message: 'Sesion iniciada correctamente' },
+            data: {
+                message: 'Sesion iniciada correctamente',
+                token: 'session-token',
+            },
         });
         authState = {
             isLoggedIn: false,
@@ -76,7 +79,7 @@ describe('Callback', () => {
             });
         });
         await waitFor(() => {
-            expect(authState.login).toHaveBeenCalledTimes(1);
+            expect(authState.login).toHaveBeenCalledWith('session-token');
         });
         expect(mockedNavigate).not.toHaveBeenCalled();
 

--- a/src/pages/Auth/Callback.tsx
+++ b/src/pages/Auth/Callback.tsx
@@ -20,8 +20,12 @@ function Callback() {
 
         const exchangeCode = async () => {
             try {
-                await api.post('/auth/google/exchange', { code });
-                await login();
+                const response = await api.post('/auth/google/exchange', { code });
+                const token =
+                    typeof response.data?.token === 'string'
+                        ? response.data.token
+                        : null;
+                await login(token);
                 setHandledExchange(true);
             } catch {
                 navigate('/', { replace: true });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:4000/api";
+const AUTH_TOKEN_STORAGE_KEY = "token";
 
 const api = axios.create({
   baseURL: API_URL,
@@ -9,5 +10,20 @@ const api = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+api.interceptors.request.use(
+  (config) => {
+    const token = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    } else if (config.headers?.Authorization) {
+      delete config.headers.Authorization;
+    }
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
 export default api;


### PR DESCRIPTION
## Resumen

Este PR agrega un fallback de autenticación por token en frontend para complementar la sesión por cookie actual.

## Motivación

Algunos navegadores móviles o webviews no están persistiendo la cookie cross-site del backend, lo que rompe el login normal y el login con Google en ciertos celulares. El objetivo es recuperar compatibilidad amplia para pruebas reales en dispositivo móvil sin desmontar el flujo actual por cookie.

## Cambios

- se reintroduce el envío de `Authorization: Bearer <token>` desde el cliente cuando exista token persistido
- `AuthProvider` vuelve a persistir el token como respaldo
- el login tradicional guarda el `token` devuelto por backend y luego sincroniza sesión
- el callback de Google guarda el `token` devuelto por `/auth/google/exchange` y luego sincroniza sesión
- se actualiza el test de callback para reflejar el nuevo comportamiento

## Impacto

- la cookie con `withCredentials` se mantiene
- si la cookie funciona, el flujo sigue operando
- si la cookie falla en ciertos celulares, el frontend puede continuar autenticando por bearer token
